### PR TITLE
:bug: GetMeetingsResponse solved bug 1 meeting

### DIFF
--- a/bigbluebutton_api_python/responses/getmeetings.py
+++ b/bigbluebutton_api_python/responses/getmeetings.py
@@ -1,3 +1,5 @@
+from jxmlease.dictnode import XMLDictNode
+
 from .base import BaseResponse
 from ..core.meeting import Meeting
 
@@ -11,6 +13,11 @@ class GetMeetingsResponse(BaseResponse):
         except KeyError:
             pass
 
-        for meetingXml in self.get_field("meetings")["meeting"]:
+        meeting_data = self.get_field("meetings")["meeting"]
+        if isinstance(meetings_data, XMLDictNode):
+            # There is only one meeting
+            meetings_data = [meetings_data]
+        
+        for meetingXml in meeting_data:
             meetings.append(Meeting(meetingXml))
         return meetings


### PR DESCRIPTION
If there is only one meeting on the server,  an error is thrown in the **for**.

```
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python3.8/site-packages/bigbluebutton_api_python/responses/getmeetings.py", line 15, in get_meetings
    meetings.append(Meeting(meetingXml))
  File "/usr/local/lib/python3.8/site-packages/bigbluebutton_api_python/core/meeting.py", line 5, in __init__
    self.__meetingId = xml["meetingID"]
TypeError: string indices must be integers
```